### PR TITLE
ref #28 Add Sentry to project

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,13 +51,16 @@ gem 'google-apis-drive_v3'
 gem 'google-apis-sheets_v4'
 
 gem 'googleauth', '~> 1.0'
+gem "sentry-rails"
+gem "sentry-ruby"
+gem 'slack-ruby-client'
+gem "stackprof"
+gem 'whenever', require: false
 
 gem 'rouge', '~> 4.2'
 gem 'rubocop'
 gem 'rubocop-capybara', '~> 2.21'
 gem 'rubocop-rails', '~> 2.27'
-gem 'slack-ruby-client'
-gem 'whenever', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -375,6 +375,12 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     semantic_range (3.1.0)
+    sentry-rails (5.22.1)
+      railties (>= 5.0)
+      sentry-ruby (~> 5.22.1)
+    sentry-ruby (5.22.1)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
     signet (0.19.0)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.a)
@@ -399,6 +405,7 @@ GEM
       sprockets (>= 3.0.0)
     sqlite3 (1.7.3-x64-mingw-ucrt)
     sqlite3 (1.7.3-x86_64-linux)
+    stackprof (0.2.27)
     tailwindcss-rails (2.5.0-x64-mingw-ucrt)
       railties (>= 6.0.0)
     tailwindcss-rails (2.5.0-x86_64-linux)
@@ -490,9 +497,12 @@ DEPENDENCIES
   rubocop-rails (~> 2.27)
   sass-rails (>= 6)
   selenium-webdriver (>= 4.0.0.rc1)
+  sentry-rails
+  sentry-ruby
   slack-ruby-client
   spring
   sqlite3 (~> 1.4)
+  stackprof
   tailwindcss-rails (~> 2.5)
   turbolinks (~> 5)
   tzinfo-data

--- a/app/controllers/test_error_controller.rb
+++ b/app/controllers/test_error_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class TestErrorController < ApplicationController
+  def test_error
+    raise StandardError, "Test error for Slack 123121"
+  end
+end

--- a/app/services/slack_notifier.rb
+++ b/app/services/slack_notifier.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# app/services/slack_notifier.rb
+class SlackNotifier
+  def self.send_error_to_slack(event)
+    slack_webhook_url = ENV['SLACK_HOOK']
+    return if slack_webhook_url.blank?
+
+    error_message = event.exception&.values&.first&.value || 'Unknown error'
+    timestamp = Time.zone.now.strftime('%Y-%m-%d %H:%M:%S')
+    sentry_url = "#{ENV['SENTRY_URL']}/#{event.event_id}"
+
+    payload = SlackPayloadBuilder.new(error_message, timestamp, sentry_url).build
+    send_to_slack(slack_webhook_url, payload)
+  end
+
+  def self.send_to_slack(slack_webhook_url, payload)
+    uri = URI(slack_webhook_url)
+
+    begin
+      response = Net::HTTP.post(uri, payload.to_json, 'Content-Type' => 'application/json')
+      Rails.logger.error("Failed to send error to Slack: #{response.body}") unless response.is_a?(Net::HTTPSuccess)
+    rescue StandardError => e
+      Rails.logger.error("Error while sending notification to Slack: #{e.message}")
+    end
+  end
+end

--- a/app/services/slack_payload_builder.rb
+++ b/app/services/slack_payload_builder.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# app/services/slack_payload_builder.rb
+class SlackPayloadBuilder
+  def initialize(error_message, timestamp, sentry_url)
+    @error_message = error_message
+    @timestamp = timestamp
+    @sentry_url = sentry_url
+  end
+
+  def build
+    {
+      text: I18n.t('messages.error_notification'),
+      attachments: [
+        {
+          color: '#ff0000',
+          fields: [
+            { title: I18n.t('messages.error_message'), value: @error_message, short: false },
+            { title: I18n.t('messages.timestamp'), value: @timestamp, short: true },
+            { title: I18n.t('messages.sentry_link'), value: "<#{@sentry_url}|#{I18n.t('messages.view_in_sentry')}>", 
+              short: false }
+          ]
+        }
+      ]
+    }
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,8 @@
 
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
   <%= render 'layouts/shim' %>
-</head>
+  <%= Sentry.get_trace_propagation_meta.html_safe %>
+  </head>
 <body>
 <header class="navbar navbar-fixed-top navbar-inverse">
   <div class="container">

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -95,7 +95,6 @@ Rails.application.configure do
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end
 
-
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Sentry.init do |config|
+  config.dsn = ENV['SENTRY_DNS']
+  config.breadcrumbs_logger = %i[active_support_logger http_logger]
+  config.traces_sample_rate = 1.0
+  config.traces_sampler = lambda do |_context|
+    true
+  end
+  config.before_send = lambda do |event, _hint|
+    SlackNotifier.send_error_to_slack(event)
+    event
+  end
+  config.profiles_sample_rate = 1.0
+end

--- a/config/initializers/slack.rb
+++ b/config/initializers/slack.rb
@@ -1,0 +1,3 @@
+Slack.configure do |config|
+  config.token = ENV['SLACK_API']
+end

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -9,3 +9,8 @@ vi:
       - %{most_commented_message}
     build_most_commented_message: "Bài viết có ID %{micropost_id} có nhiều comment nhất với %{count} comment."
     micropost_url_message: "URL bài viết: http://127.0.0.1:3000/microposts/%{micropost_id}"
+    error_notification: "*Thông báo lỗi từ Sentry* :rotating_light:"
+    error_message: "Tin nhắn lỗi"
+    timestamp: "Thời gian"
+    sentry_link: "Liên kết Sentry"
+    view_in_sentry: "Xem trong Sentry"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   post '/login', to: 'sessions#create'
 
   get '/auth/:provider/callback', to: 'sessions#create_third_party'
+  get '/test_error', to: 'test_error#test_error'
 
   post '/microposts/reactions', to: 'reactions#create', as: 'reactions'
   delete '/microposts/:micropost_id/reactions', to: 'reactions#destroy', as: 'destroy_reaction'

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 every 1.day, at: '8:00 am', tz: 'Asia/Ho_Chi_Minh' do
   runner 'ReportService.send_daily_report'
 end

--- a/spec/helpers/test_error_helper_spec.rb
+++ b/spec/helpers/test_error_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the TestErrorHelper. For example:
+#
+# describe TestErrorHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe TestErrorHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/initializers/sentry_spec.rb
+++ b/spec/initializers/sentry_spec.rb
@@ -1,0 +1,14 @@
+# spec/initializers/sentry_spec.rb
+require 'rails_helper'
+RSpec.describe 'Sentry Initialization', type: :initialization do
+  let(:event) { double('event', exception: { 'error' => double('value', value: 'Test Error') }, event_id: '12345') }
+
+  before do
+    allow(SlackNotifier).to receive(:send_error_to_slack)
+  end
+
+  it 'calls SlackNotifier.send_error_to_slack before sending an event to Sentry' do
+    Sentry.configuration.before_send.call(event, nil)
+    expect(SlackNotifier).to have_received(:send_error_to_slack).with(event)
+  end
+end

--- a/spec/requests/test_error_spec.rb
+++ b/spec/requests/test_error_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe 'GoogleSheets', type: :request do
-  describe 'GET /index' do
+RSpec.describe "TestErrors", type: :request do
+  describe "GET /index" do
     pending "add some examples (or delete) #{__FILE__}"
   end
 end

--- a/spec/services/slack_notifier_spec.rb
+++ b/spec/services/slack_notifier_spec.rb
@@ -1,0 +1,25 @@
+# spec/services/slack_notifier_spec.rb
+require 'rails_helper'
+
+RSpec.describe SlackNotifier, type: :service do
+  describe '.send_error_to_slack' do
+    let(:event) { double('event', exception: { 'error' => double('value', value: 'Test Error') }, event_id: '12345') }
+    let(:slack_webhook_url) { 'https://hooks.slack.com/test' }
+    let(:sentry_url) { 'https://sentry.io/test_project' }
+
+    before do
+      allow(ENV).to receive(:[]).with('SLACK_HOOK').and_return(slack_webhook_url)
+      allow(ENV).to receive(:[]).with('SENTRY_URL').and_return(sentry_url)
+      allow(SlackNotifier).to receive(:send_to_slack)
+    end
+
+    it 'sends an error message to Slack' do
+      SlackNotifier.send_error_to_slack(event)
+
+      expect(SlackNotifier).to have_received(:send_to_slack).with(
+        slack_webhook_url,
+        kind_of(Hash)
+      )
+    end
+  end
+end


### PR DESCRIPTION
### Task Description:
When an error is logged in Sentry, I want to be notified immediately in a Slack channel with:
- The error message.
- The timestamp when the error occurred.
- A link to the error details in Sentry.
### Completion time
-4 hours
### Video demo

https://github.com/user-attachments/assets/97903641-d006-4142-a134-86d18bfac875

